### PR TITLE
Use weekday names for header nav buttons

### DIFF
--- a/vacation-planner.js
+++ b/vacation-planner.js
@@ -899,7 +899,7 @@ function renderDayNavigation(dates) {
         btn.dataset.date = date;
         btn.style.color = color;
         btn.style.borderColor = color;
-        btn.textContent = `Day ${index + 1}`;
+        btn.textContent = `${weekday} ${index + 1}`;
         btn.title = `${weekday} ${formatDate(date)}`;
         
         btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- show weekday abbreviation with index on day nav buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688584032a90832882021b5e4e78b2f9