### PR TITLE
feat: add daily weather inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,18 @@
                     <label for="dayColorInput">Day Color</label>
                     <input type="color" id="dayColorInput" class="color-input">
                 </div>
+                <div class="form-group">
+                    <label>Temperatures</label>
+                    <div class="form-row">
+                        <input type="text" id="dayTempMorning" placeholder="Morning">
+                        <input type="text" id="dayTempDay" placeholder="Day">
+                        <input type="text" id="dayTempNight" placeholder="Night">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="dayForecastInput">Forecast</label>
+                    <input type="text" id="dayForecastInput" placeholder="e.g., Sunny with light showers">
+                </div>
             </div>
             <div class="modal-footer">
                 <button onclick="closeDayEditModal()" class="btn btn-cancel">

--- a/vacation-planner.css
+++ b/vacation-planner.css
@@ -517,6 +517,23 @@ body {
     flex-wrap: wrap;
 }
 
+.day-weather {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 14px;
+    color: #555;
+}
+
+.day-temps {
+    font-weight: 500;
+}
+
+.day-forecast {
+    font-style: italic;
+}
+
 .preview-icon {
     width: 32px;
     height: 32px;

--- a/vacation-planner.js
+++ b/vacation-planner.js
@@ -404,11 +404,15 @@ function clearAll() {
 function openDayEditModal(date) {
     const modal = document.getElementById('dayEditModal');
     const dayDetails = dayLabels.find(d => d.date === date);
-    
+
     document.getElementById('dayEditDate').value = date;
     document.getElementById('dayLabelInput').value = dayDetails?.label || '';
     document.getElementById('dayColorInput').value = dayDetails?.color || '#f44336';
-    
+    document.getElementById('dayTempMorning').value = dayDetails?.tempMorning || '';
+    document.getElementById('dayTempDay').value = dayDetails?.tempDay || '';
+    document.getElementById('dayTempNight').value = dayDetails?.tempNight || '';
+    document.getElementById('dayForecastInput').value = dayDetails?.forecast || '';
+
     modal.style.display = 'block';
 }
 
@@ -420,13 +424,21 @@ function saveDayDetails() {
     const date = document.getElementById('dayEditDate').value;
     const label = document.getElementById('dayLabelInput').value.trim();
     const color = document.getElementById('dayColorInput').value;
+    const tempMorning = document.getElementById('dayTempMorning').value.trim();
+    const tempDay = document.getElementById('dayTempDay').value.trim();
+    const tempNight = document.getElementById('dayTempNight').value.trim();
+    const forecast = document.getElementById('dayForecastInput').value.trim();
 
     const dayDetails = dayLabels.find(d => d.date === date);
     if (dayDetails) {
         dayDetails.label = label;
         dayDetails.color = color;
+        dayDetails.tempMorning = tempMorning;
+        dayDetails.tempDay = tempDay;
+        dayDetails.tempNight = tempNight;
+        dayDetails.forecast = forecast;
     } else {
-        dayLabels.push({ date, label, color });
+        dayLabels.push({ date, label, color, tempMorning, tempDay, tempNight, forecast });
     }
     renderAll();
     closeDayEditModal();
@@ -573,6 +585,10 @@ function renderDestinations() {
         daySeparator.style.color = dayColor;
         
         const dayLabelText = dayDetails?.label || 'Add a title for this day...';
+        const temps = [dayDetails?.tempMorning, dayDetails?.tempDay, dayDetails?.tempNight].filter(t => t);
+        const tempsHtml = temps.length > 0 ? `<div class="day-temps">${temps.join(' / ')}</div>` : '';
+        const forecastHtml = dayDetails?.forecast ? `<div class="day-forecast">${dayDetails.forecast}</div>` : '';
+        const weatherHtml = (tempsHtml || forecastHtml) ? `<div class="day-weather">${tempsHtml}${forecastHtml}</div>` : '';
         
         let dayTotalTime = 0;
         const categoryCounts = {};
@@ -617,6 +633,7 @@ function renderDestinations() {
                     <button class="btn btn-edit-day" onclick="openDayEditModal('${date}')" title="Edit day title"><i class="fas fa-pencil-alt"></i></button>
                 </div>
             </div>
+            ${weatherHtml}
             <div class="day-preview">${previewHtml}</div>
         `;
 


### PR DESCRIPTION
## Summary
- allow editing morning, day, night temperatures and a forecast for each day
- show stored temperatures and forecast under each day's description
- style new weather section in day blocks

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e1b6a9ff483289cd976cbc397d942