### PR TITLE
feat: display forecast with degree symbols

### DIFF
--- a/vacation-planner.js
+++ b/vacation-planner.js
@@ -586,7 +586,9 @@ function renderDestinations() {
         
         const dayLabelText = dayDetails?.label || 'Add a title for this day...';
         const temps = [dayDetails?.tempMorning, dayDetails?.tempDay, dayDetails?.tempNight].filter(t => t);
-        const tempsHtml = temps.length > 0 ? `<div class="day-temps">${temps.join(' / ')}</div>` : '';
+        const tempsHtml = temps.length > 0
+            ? `<div class="day-temps">Forecast: ${temps.map(t => `${t.replace(/°/g, '')}°`).join(' / ')}</div>`
+            : '';
         const forecastHtml = dayDetails?.forecast ? `<div class="day-forecast">${dayDetails.forecast}</div>` : '';
         const weatherHtml = (tempsHtml || forecastHtml) ? `<div class="day-weather">${tempsHtml}${forecastHtml}</div>` : '';
         


### PR DESCRIPTION
## Summary
- show day temperature forecasts as `Forecast: 45° / 50° / 48°`

## Testing
- `node --check vacation-planner.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e21554e7483288d387b4c3e97a5ff